### PR TITLE
Remove premature return from message handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,7 +140,6 @@ func sendMessage(ctx context.Context,
 					logger.WithField("Error", respErr).Warn("Failed to post to connection")
 				}
 			}
-			return true
 		}
 		return true
 	}


### PR DESCRIPTION
Removing the return statement that exits the loop before all the connections have been handled.